### PR TITLE
[FIX] Exception type

### DIFF
--- a/src/main/java/jp/co/gsol/oss/ical/io/DocumentFileWriter.java
+++ b/src/main/java/jp/co/gsol/oss/ical/io/DocumentFileWriter.java
@@ -80,7 +80,7 @@ public class DocumentFileWriter {
     private static final Path getCanonicalPath(final Path dir)
             throws NoSuchDirectoryException {
         if (!dir.isAbsolute())
-            throw new IllegalArgumentException(dir + " is not abusolute path");
+            throw new NoSuchDirectoryException(dir + " is not abusolute path");
         if (!Files.isDirectory(dir))
             throw new NoSuchDirectoryException(dir + " not found");
         return dir;


### PR DESCRIPTION
## What

* DogumentFileWriter#getCanonicalPath throws NoSuchDirectoryExcption instead of IllegualArgumentExcpetion

## Why

* uncaught by caller