### PR TITLE
[FIX] ファイル再生成時の期待しないファイル削除を修正

### DIFF
--- a/src/main/java/jp/co/gsol/oss/ical/logic/ICalUserDataManipulatorLogic.java
+++ b/src/main/java/jp/co/gsol/oss/ical/logic/ICalUserDataManipulatorLogic.java
@@ -99,9 +99,10 @@ public class ICalUserDataManipulatorLogic {
     public final String deleteAndCreateUserData(final String userCd,
             final DateTime time)
             throws IOException, ICalException {
-        final String filename = getFileName(userCd);
-        if (filename != null) deleteFile(filename);
-        return createUserData(userCd, time);
+        final String oldFilename = getFileName(userCd);
+        final String newFilename = createUserData(userCd, time);
+        if (oldFilename != null) deleteFile(oldFilename);
+        return newFilename;
     }
 
     /**


### PR DESCRIPTION
## What

* ファイル再生成時、旧ファイル削除前に、新ファイルを生成する

## Why

* 新ファイル生成に失敗すると、旧ファイルも新ファイルもない状態になってしまう